### PR TITLE
Add support for light theme based on background nvim configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 THIS IS IN DEVELOPEMENT FOR NOW
 
-A port of [gruvbox-material](https://github.com/sainnhe/gruvbox-material) colorscheme for Neovim written in Lua.
+A port of [gruvbox-material](https://github.com/sainnhe/gruvbox-material) colorscheme for Neovim written in Lua. Supports both `dark` and `light` themes, based on configured background.
 
 Gruvbox Material is a modified version of Gruvbox, the contrast is adjusted to be softer in order to protect developers' eyes. Colorscheme supports a lot of new features added to Neovim like built-in LSP and [Treesitter](https://github.com/nvim-treesitter/nvim-treesitter).
 

--- a/lua/gruvbox-material/colors.lua
+++ b/lua/gruvbox-material/colors.lua
@@ -1,45 +1,93 @@
 local colors = {
-  red = '#ea6962',
-  orange = '#e78a4e',
-  yellow = '#d8a657',
-  green = '#a9b665',
-  aqua = '#89b482',
-  blue = "#7daea3",
-  purple = "#d3869b",
+  dark = {
+    red = '#ea6962',
+    orange = '#e78a4e',
+    yellow = '#d8a657',
+    green = '#a9b665',
+    aqua = '#89b482',
+    blue = '#7daea3',
+    purple = '#d3869b',
 
-  bg_yellow = '#d8a657',
-  bg_red = '#ea6962',
-  bg_green = '#a9b665',
+    bg_yellow = '#d8a657',
+    bg_red = '#ea6962',
+    bg_green = '#a9b665',
 
-  grey0 = '#7c6f64',
-  grey1 = '#928374',
-  grey2 = '#a89984',
+    grey0 = '#7c6f64',
+    grey1 = '#928374',
+    grey2 = '#a89984',
 
-  bg_diff_red = '#402120',
-  bg_diff_green = '#34381b',
-  bg_diff_blue = '#0e363e',
+    bg_diff_red = '#402120',
+    bg_diff_green = '#34381b',
+    bg_diff_blue = '#0e363e',
 
-  fg0 = '#d4be98',
-  fg1 = '#ddc7a1',
+    fg0 = '#d4be98',
+    fg1 = '#ddc7a1',
 
-  -- background = medium
-  bg0 = '#282828',
-  bg1 = '#32302f',
-  bg2 = '#32302f',
-  bg3 = '#45403d',
-  bg4 = '#45403d',
-  bg5 = '#5a524c',
-  bg_statusline1 = '#32302f',
-  bg_statusline2 = '#3a3735',
-  bg_statusline3 = '#504945',
-  bg_visual_green = '#3b4439',
-  bg_visual_red = '#4c3432',
-  bg_visual_blue = '#374141',
-  bg_visual_yellow = '#4f422e',
-  bg_current_word = '#3c3836',
+    -- background = medium
+    bg0 = '#282828',
+    bg1 = '#32302f',
+    bg2 = '#32302f',
+    bg3 = '#45403d',
+    bg4 = '#45403d',
+    bg5 = '#5a524c',
+    bg_statusline1 = '#32302f',
+    bg_statusline2 = '#3a3735',
+    bg_statusline3 = '#504945',
+    bg_visual_green = '#3b4439',
+    bg_visual_red = '#4c3432',
+    bg_visual_blue = '#374141',
+    bg_visual_yellow = '#4f422e',
+    bg_current_word = '#3c3836',
 
-  term = {
-    bg5 = 239
+    term = {
+      bg5 = 239
+    }
+  },
+
+  light = {
+    red = '#c14a4a',
+    orange = '#c35e0a',
+    yellow = '#b47109',
+    green = '#6c782e',
+    aqua = '#4c7a5d',
+    blue = '#45707a',
+    purple = '#945e80',
+
+    bg_yellow = '#a96b2c',
+    bg_red = '#ae5858',
+    bg_green = '#6f8352',
+
+    grey0 = '#7c6f64',
+    grey1 = '#928374',
+    grey2 = '#a89984',
+
+    bg_diff_red = '#f9e0bb',
+    bg_diff_green = '#e6eabc',
+    bg_diff_blue = '#e2e6c7',
+
+    fg0 = '#654735',
+    fg1 = '#4f3829',
+
+    -- background = medium
+    bg0 = '#fbf1c7',
+    bg1 = '#f4e8be',
+    bg2 = '#f2e5bc',
+    bg3 = '#eee0b7',
+    bg4 = '#e5d5ad',
+    bg5 = '#ddccab',
+    bg_statusline1 = '#f2e5bc',
+    bg_statusline2 = '#f2e5bc',
+    bg_statusline3 = '#e5d5ad',
+    bg_visual_green = '#dee2b6',
+    bg_visual_red = '#f1d9b5',
+    bg_visual_blue = '#dadec0',
+    bg_visual_yellow = '#fae7b3',
+    bg_current_word = '#f2e5bc',
+
+    term = {
+      bg5 = 250
+    }
+
   }
 }
 

--- a/lua/gruvbox-material/highlights.lua
+++ b/lua/gruvbox-material/highlights.lua
@@ -1,4 +1,8 @@
-local colors = require('gruvbox-material.colors')
+local g_colors = require('gruvbox-material.colors')
+local colors = g_colors.dark
+if vim.o.background == "light" then
+  colors = g_colors.light
+end
 
 local g = vim.g
 local opt = vim.opt

--- a/lua/gruvbox-material/utils.lua
+++ b/lua/gruvbox-material/utils.lua
@@ -1,4 +1,4 @@
-utils = {}
+local utils = {}
 
 function utils.highlight(group, color)
   local fg = color.fg or "NONE"


### PR DESCRIPTION
Port of the light material gruvbox theme. Selects the theme automatically based on configured vim background. Tested.